### PR TITLE
Implement user-overridable retention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
   - pip install poetry
 install:
   - poetry install
-before_script:
-  - sudo snap install microk8s --classic --channel=1.15/stable
-  - sudo microk8s.status --wait-ready
-  - sudo microk8s.kubectl config view --raw > $HOME/microk8s.conf
+# before_script:
+#   - sudo snap install microk8s --classic --channel=1.14/stable
+#   - sudo microk8s.status --wait-ready
+#   - sudo microk8s.kubectl config view --raw > $HOME/microk8s.conf
 script:
   - pytest
-  - TEST_K8S_CONFIG_PATH=$HOME/microk8s.conf pytest -m k8s_itest
+  # - TEST_K8S_CONFIG_PATH=$HOME/microk8s.conf pytest -m k8s_itest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
   - poetry install
 before_script:
-  - sudo snap install microk8s --classic --channel=1.14/stable
+  - sudo snap install microk8s --classic --channel=1.15/stable
   - sudo microk8s.status --wait-ready
   - sudo microk8s.kubectl config view --raw > $HOME/microk8s.conf
 script:

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Labels:
   (maps to a name in the manager config).
 
 Annotations:
+
 * ``job_deletion_time_unix_sec``: If present, the earliest time at which the job can be
   deleted. It is only set after the job has reached a terminal state. This is meant to
   help implement baseline retention for resource management purposes, as well as to

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 K8s Jobs
 =========
 
+.. image:: https://badge.fury.io/py/k8s-jobs.svg
+    :target: https://badge.fury.io/py/k8s-jobs
 .. image:: https://travis-ci.com/danieltahara/k8s-jobs.svg?token=cZTmQ2jMoLFe6Ve33X6M&branch=master
 
 K8s Jobs is a library for implementing an asynchronous job server on Kubernetes. It is
@@ -9,11 +11,8 @@ commands (unlike something like Celery that can have arbitrary fanout and nestin
 well as a server implementation that can stand in as a replacement for AWS Batch and
 trigger jobs on-command.
 
-What's Inside
--------------
-
 Kubernetes Job Management
-+++++++++++++++++++++++++
+-------------------------
 
 This project provides an abstraction around kubernetes APIs to allow you to dynamically
 spawn (templated) jobs and clean up after them when they have run.
@@ -39,7 +38,7 @@ Controller
 <https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/>`_.
 
 Labeling and Annotations
-~~~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++++
 
 The ``JobManager`` (and associated objects) makes use of `labels and annotations
 <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`_ in
@@ -60,10 +59,13 @@ Annotations:
   provide an avenue for users to mark and prevent the deletion of a job so that it can
   be inspected for debugging.
 
-Example Flask Server
-++++++++++++++++++++
+Examples
+--------
 
-The server is a proof-of-concept impleemtnation intended as a replacement for and
+Flask Server
+++++++++++++
+
+The server is a proof-of-concept implementation intended as a replacement for and
 extension to AWS Batch. It is a flask application housed completely under
 ``examples/flask``. You do not need to use the server in order to take advantage of the
 primitives on which it relies.
@@ -101,6 +103,3 @@ To run the sample server locally (make sure you have ``~/.kube/config`` configur
 .. code:: bash
 
   JOB_SIGNATURE=foo JOB_NAMESPACE=default JOB_DEFINITIONS_CONFIG_PATH=path/to/conf python examples/flask/app.py
-
-Configuration
--------------

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,28 @@ and to avoid using a feature that is still in Alpha. For more details, see the `
 Controller
 <https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/>`_.
 
+Labeling and Annotations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``JobManager`` (and associated objects) makes use of `labels and annotations
+<https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`_ in
+order to properly identify and manage jobs. Of note are the following:
+
+Labels:
+
+* ``app.kubernetes.io/managed-by``: A recommended kubernetes label, populated with the
+  value of the ``JobSigner`` signature. This is used to logically identify jobs created
+  by the ``JobManager`` of interest, rather than by third party applications or users.
+* ``job_definition_name``: Identifies the job definition on which the job was based
+  (maps to a name in the manager config).
+
+Annotations:
+* ``job_deletion_time_unix_sec``: If present, the earliest time at which the job can be
+  deleted. It is only set after the job has reached a terminal state. This is meant to
+  help implement baseline retention for resource management purposes, as well as to
+  provide an avenue for users to mark and prevent the deletion of a job so that it can
+  be inspected for debugging.
+
 Example Flask Server
 ++++++++++++++++++++
 
@@ -79,3 +101,6 @@ To run the sample server locally (make sure you have ``~/.kube/config`` configur
 .. code:: bash
 
   JOB_SIGNATURE=foo JOB_NAMESPACE=default JOB_DEFINITIONS_CONFIG_PATH=path/to/conf python examples/flask/app.py
+
+Configuration
+-------------

--- a/k8s_jobs/manager.py
+++ b/k8s_jobs/manager.py
@@ -326,7 +326,7 @@ class JobDeleter:
             except client.rest.ApiException:
                 logger.warning(f"Error checking job {job.metadata.name}", exc_info=True)
 
-    def delete_old_jobs(
+    def mark_and_delete_old_jobs(
         self,
         *,
         retention_period_sec: int,
@@ -350,7 +350,7 @@ class JobDeleter:
         Arguments:
             interval_sec: time between loops, including the time it takes to perform a
                 check + delete.
-            **kwargs: Arguments to delete_old_jobs
+            **kwargs: Arguments to mark_and_delete_old_jobs
 
         Returns:
             Callable to stop the cleanup loop
@@ -365,7 +365,7 @@ class JobDeleter:
                     if _stopped:
                         return
                 try:
-                    self.delete_old_jobs(**kwargs)
+                    self.mark_and_delete_old_jobs(**kwargs)
                 except Exception as err:
                     logger.warning(err, exc_info=True)
                 time.sleep(max(0, interval_sec - (time.time() - start)))

--- a/k8s_jobs/manager.py
+++ b/k8s_jobs/manager.py
@@ -211,7 +211,7 @@ class JobManager:
             logs += "======="
         return logs
 
-    def job_is_finished(self, job: client.V1Job, retention_period_sec: int) -> bool:
+    def job_is_finished(self, job: client.V1Job) -> bool:
         """
         Inspects the job status, and if it is in a terminal state, returns True.
 

--- a/k8s_jobs/manager.py
+++ b/k8s_jobs/manager.py
@@ -295,7 +295,7 @@ class JobDeleter:
             try:
                 if self.manager.job_is_finished(job):
                     self.mark_deletion_time(job, retention_period_sec)
-            except client.ApiException:
+            except client.rest.ApiException:
                 logger.warning("Error marking job", exc_info=True)
 
     def cleanup_jobs(
@@ -322,7 +322,7 @@ class JobDeleter:
                 except Exception:
                     logger.warning(f"Error in delete callback", exc_info=True)
                     continue
-                self.delete_job(job)
+                self.manager.delete_job(job)
             except client.rest.ApiException:
                 logger.warning(f"Error checking job {job.metadata.name}", exc_info=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "k8s-jobs"
-version = "0.1.5"
+version = "0.1.6"
 description = "Async Job Manager + AWS Batch Replacement for K8s"
 authors = ["Daniel Tahara <dktahara@gmail.com>"]
 repository = "https://github.com/danieltahara/k8s-jobs"

--- a/test/integration/test_manager.py
+++ b/test/integration/test_manager.py
@@ -41,7 +41,7 @@ def manager(request, register):
 
 
 def wait_for_completion(manager: JobManager, job_name: str):
-    while not manager.job_is_complete(job_name):
+    while not manager.job_is_finished(job_name):
         time.sleep(1)
 
 

--- a/test/integration/test_manager.py
+++ b/test/integration/test_manager.py
@@ -76,11 +76,10 @@ class TestManager:
             _ = manager.read_job(job_name)
             _ = manager.job_logs(job_name)
 
-        # Delete
-        JobDeleter(manager).delete_old_jobs(retention_period_sec=0)
-        wait_for_deletion(manager)
+        for job in manager.fetch_jobs():
+            manager.delete_job(job)
 
-    def test_delete_old_jobs(self, manager):
+    def test_mark_and_delete_old_jobs(self, manager):
         NUM_JOBS = 3
 
         job_names = [manager.create_job("job-helloworld") for i in range(NUM_JOBS)]
@@ -90,10 +89,7 @@ class TestManager:
         for job_name in job_names:
             wait_for_completion(manager, job_name)
 
-        JobDeleter(manager).delete_old_jobs(retention_period_sec=3600)
-        assert len(manager.list_jobs()) == NUM_JOBS
-
-        JobDeleter(manager).delete_old_jobs(retention_period_sec=0)
+        JobDeleter(manager).mark_and_delete_old_jobs(retention_period_sec=0)
         wait_for_deletion(manager)
 
     def test_not_found(self, manager):

--- a/test/integration/test_manager.py
+++ b/test/integration/test_manager.py
@@ -4,7 +4,12 @@ import time
 import pytest
 
 from k8s_jobs.exceptions import NotFoundException
-from k8s_jobs.manager import JobManager, JobSigner, StaticJobDefinitionsRegister
+from k8s_jobs.manager import (
+    JobDeleter,
+    JobManager,
+    JobSigner,
+    StaticJobDefinitionsRegister,
+)
 from k8s_jobs.spec import JobGenerator, YamlFileSpecSource
 from test.fixtures.examples import ALL_JOB_DEFINITION_NAMES, EXAMPLES_ROOT
 
@@ -72,7 +77,7 @@ class TestManager:
             _ = manager.job_logs(job_name)
 
         # Delete
-        manager.delete_old_jobs(retention_period_sec=0)
+        JobDeleter(manager).delete_old_jobs(retention_period_sec=0)
         wait_for_deletion(manager)
 
     def test_delete_old_jobs(self, manager):
@@ -85,10 +90,10 @@ class TestManager:
         for job_name in job_names:
             wait_for_completion(manager, job_name)
 
-        manager.delete_old_jobs(retention_period_sec=3600)
+        JobDeleter(manager).delete_old_jobs(retention_period_sec=3600)
         assert len(manager.list_jobs()) == NUM_JOBS
 
-        manager.delete_old_jobs(retention_period_sec=0)
+        JobDeleter(manager).delete_old_jobs(retention_period_sec=0)
         wait_for_deletion(manager)
 
     def test_not_found(self, manager):

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -412,7 +412,7 @@ class TestJobDeleter:
 
     def test_run_background_cleanup(self):
         deleter = JobDeleter(Mock())
-        with patch.object(deleter, "delete_old_jobs") as _:
+        with patch.object(deleter, "mark_and_delete_old_jobs") as _:
             stop = deleter.run_background_cleanup(0)
 
             stop()

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -311,21 +311,22 @@ class TestJobDeleter:
         namespace = "abcxyz"
         manager = Mock(namespace=namespace)
         deleter = JobDeleter(manager)
-        job = V1Job(metadata=V1ObjectMeta(name=name, annotations={}))
 
+        job = V1Job(metadata=V1ObjectMeta(name=name, annotations={}))
         deleter.mark_deletion_time(job, 3600)
         mock_batch_client.patch_namespaced_job.assert_called_once_with(
             name=name, namespace=namespace, body=ANY
         )
-        deletion_time_1 = mock_batch_client.call_args[1]["body"].metadata.annotations[
-            deleter.JOB_DELETION_TIME_ANNOTATION
-        ]
+        deletion_time_1 = mock_batch_client.patch_namespaced_job.call_args[1][
+            "body"
+        ].metadata.annotations[deleter.JOB_DELETION_TIME_ANNOTATION]
         mock_batch_client.reset_mock()
 
+        job = V1Job(metadata=V1ObjectMeta(name=name, annotations={}))
         deleter.mark_deletion_time(job, 0)
-        deletion_time_2 = mock_batch_client.call_args[1]["body"].metadata.annotations[
-            deleter.JOB_DELETION_TIME_ANNOTATION
-        ]
+        deletion_time_2 = mock_batch_client.patch_namespaced_job.call_args[1][
+            "body"
+        ].metadata.annotations[deleter.JOB_DELETION_TIME_ANNOTATION]
 
         assert deletion_time_1 > deletion_time_2
 

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime
+import time
 from unittest.mock import ANY, Mock, patch
 
 from kubernetes.client import (
@@ -15,6 +16,7 @@ from kubernetes.client.rest import ApiException
 import pytest
 
 from k8s_jobs.manager import (
+    JobDeleter,
     JobManager,
     JobSigner,
     NotFoundException,
@@ -134,102 +136,37 @@ class TestJobManager:
             body=V1DeleteOptions(propagation_policy="Foreground"),
         )
 
-    def test_is_candidate_for_deletion(self):
-        manager = JobManager(
-            namespace="fake", signer=Mock(), register=StaticJobDefinitionsRegister()
-        )
-        now = datetime.now()
-        before = now - timedelta(seconds=101)
+    def test_job_is_finished(self):
+        manager = JobManager(namespace="xyz", signer=Mock(), register=Mock())
 
         job = V1Job(status=V1JobStatus(conditions=[]))
-        assert not manager.is_candidate_for_deletion(job, 100)
+        assert not manager.job_is_finished(job)
 
-        job = V1Job(status=V1JobStatus(conditions=[], completion_time=now))
-        assert not manager.is_candidate_for_deletion(job, 100)
-
-        job = V1Job(
-            status=V1JobStatus(
-                conditions=[
-                    V1JobCondition(
-                        last_transition_time=now, status="True", type="Complete"
-                    )
-                ]
-            )
-        )
-        assert not manager.is_candidate_for_deletion(
-            job, 100
-        ), "A recently completed job should not be deleted"
+        job = V1Job(status=V1JobStatus(conditions=[], completion_time=datetime.now()))
+        assert not manager.job_is_finished(job), "Completion time field is unchecked"
 
         job = V1Job(
             status=V1JobStatus(
-                conditions=[
-                    V1JobCondition(
-                        last_transition_time=before, status="True", type="Complete"
-                    )
-                ]
+                conditions=[V1JobCondition(status="True", type="Complete")]
             )
         )
-        assert manager.is_candidate_for_deletion(
-            job, 100
-        ), "Job that completed a while ago should be deleted"
+        assert manager.job_is_finished(job), "A complete job should be finished"
 
         job = V1Job(
             status=V1JobStatus(
-                conditions=[
-                    V1JobCondition(
-                        last_transition_time=before, status="False", type="Complete"
-                    )
-                ]
+                conditions=[V1JobCondition(status="False", type="Complete")]
             )
         )
-        assert not manager.is_candidate_for_deletion(
-            job, 100
+        assert not manager.job_is_finished(
+            job
         ), "False job status conditions should be ignored"
 
         job = V1Job(
             status=V1JobStatus(
-                conditions=[
-                    V1JobCondition(
-                        last_transition_time=before, status="True", type="Failed"
-                    )
-                ]
+                conditions=[V1JobCondition(status="True", type="Failed")]
             )
         )
-        assert manager.is_candidate_for_deletion(
-            job, 100
-        ), "Job that failed a while ago should be deleted"
-
-    def test_delete_old_jobs_error(self, mock_batch_client):
-        manager = JobManager(
-            namespace="harhar", signer=Mock(), register=StaticJobDefinitionsRegister()
-        )
-
-        with patch.object(
-            manager, "delete_job", side_effect=[ApiException, None]
-        ) as mock_delete_job:
-            with patch.object(manager, "fetch_jobs", return_value=[Mock(), Mock()]):
-                with patch.object(
-                    manager, "is_candidate_for_deletion", return_value=True
-                ):
-                    # Should not raise
-                    manager.delete_old_jobs()
-
-                assert mock_delete_job.call_count == 2
-
-    def test_delete_old_jobs_callback(self, mock_batch_client):
-        manager = JobManager(
-            namespace="owahhh", signer=Mock(), register=StaticJobDefinitionsRegister()
-        )
-        with patch.object(manager, "delete_job", return_value=None):
-            with patch.object(manager, "fetch_jobs", return_value=[Mock(), Mock()]):
-                with patch.object(
-                    manager, "is_candidate_for_deletion", return_value=True
-                ):
-                    mock_callback = Mock()
-
-                    manager.delete_old_jobs(delete_callback=mock_callback)
-
-                    assert mock_callback.call_count == 2
+        assert manager.job_is_finished(job), "A failed job is finished"
 
     def test_fetch_jobs(self, mock_batch_client):
         mock_batch_client.list_namespaced_job.return_value = V1JobList(
@@ -366,6 +303,107 @@ class TestJobManager:
         assert all([name in log for name in names]), "Should print both pod names"
         assert all([log_msg in log for log_msg in log_msgs]), "Should print both logs"
         assert mock_core_client.read_namespaced_pod_log.call_count == 2
+
+
+class TestJobDeleter:
+    def test_mark_deletion_time(self, mock_batch_client):
+        name = "deletionjob"
+        namespace = "abcxyz"
+        manager = Mock(namespace=namespace)
+        deleter = JobDeleter(manager)
+        job = V1Job(metadata=V1ObjectMeta(name=name, annotations={}))
+
+        deleter.mark_deletion_time(job, 3600)
+        mock_batch_client.patch_namespaced_job.assert_called_once_with(
+            name=name, namespace=namespace, body=ANY
+        )
+        deletion_time_1 = mock_batch_client.call_args[1]["body"].metadata.annotations[
+            deleter.JOB_DELETION_TIME_ANNOTATION
+        ]
+        mock_batch_client.reset_mock()
+
+        deleter.mark_deletion_time(job, 0)
+        deletion_time_2 = mock_batch_client.call_args[1]["body"].metadata.annotations[
+            deleter.JOB_DELETION_TIME_ANNOTATION
+        ]
+
+        assert deletion_time_1 > deletion_time_2
+
+    def test_mark_deletion_time_existing_annotation(self, mock_batch_client):
+        name = "deletionjobalreadyannotated"
+        namespace = "xyzabc"
+        manager = Mock(namespace=namespace)
+        deleter = JobDeleter(manager)
+        job = V1Job(
+            metadata=V1ObjectMeta(
+                name=name, annotations={JobDeleter.JOB_DELETION_TIME_ANNOTATION: 0}
+            )
+        )
+
+        deleter.mark_deletion_time(job, 0)
+
+        mock_batch_client.patch_namespaced_job.assert_not_called()
+
+    def test_is_candidate_for_deletion(self):
+        deleter = JobDeleter(Mock())
+
+        # No annotation
+        assert not deleter.is_candidate_for_deletion(V1Job(metadata=V1ObjectMeta()))
+        assert not deleter.is_candidate_for_deletion(
+            V1Job(metadata=V1ObjectMeta(annotations={}))
+        )
+        # Wayyyy in the past
+        assert deleter.is_candidate_for_deletion(
+            V1Job(
+                metadata=V1ObjectMeta(
+                    annotations={JobDeleter.JOB_DELETION_TIME_ANNOTATION: 0}
+                )
+            )
+        )
+        # Far in the future
+        assert not deleter.is_candidate_for_deletion(
+            V1Job(
+                metadata=V1ObjectMeta(
+                    annotations={
+                        JobDeleter.JOB_DELETION_TIME_ANNOTATION: int(
+                            time.time() + 10000
+                        )
+                    }
+                )
+            )
+        )
+
+    def test_delete_old_jobs_error(self, mock_batch_client):
+        manager = JobManager(
+            namespace="harhar", signer=Mock(), register=StaticJobDefinitionsRegister()
+        )
+
+        with patch.object(
+            manager, "delete_job", side_effect=[ApiException, None]
+        ) as mock_delete_job:
+            with patch.object(manager, "fetch_jobs", return_value=[Mock(), Mock()]):
+                with patch.object(
+                    manager, "is_candidate_for_deletion", return_value=True
+                ):
+                    # Should not raise
+                    manager.delete_old_jobs()
+
+                assert mock_delete_job.call_count == 2
+
+    def test_delete_old_jobs_callback(self, mock_batch_client):
+        manager = JobManager(
+            namespace="owahhh", signer=Mock(), register=StaticJobDefinitionsRegister()
+        )
+        with patch.object(manager, "delete_job", return_value=None):
+            with patch.object(manager, "fetch_jobs", return_value=[Mock(), Mock()]):
+                with patch.object(
+                    manager, "is_candidate_for_deletion", return_value=True
+                ):
+                    mock_callback = Mock()
+
+                    manager.delete_old_jobs(delete_callback=mock_callback)
+
+                    assert mock_callback.call_count == 2
 
     def test_run_background_cleanup(self):
         manager = JobManager(namespace="foo", signer=Mock(), register=Mock())


### PR DESCRIPTION
Refactors job retention in two ways:
1. Done by an object that is not the JobManager. This improves testability and code structure
2. Uses an annotation specifying an earliest deletion to implement retention, rather than by inspecting job status. This opens a path for users to override retention for debugging purposes.

Resolves: https://github.com/danieltahara/k8s-jobs/issues/17
Addresses some of https://github.com/danieltahara/k8s-jobs/issues/16