### PR TITLE
Add YAML String Spec Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.egg-info/
 dist/
+.coverage

--- a/k8s_jobs/config.py
+++ b/k8s_jobs/config.py
@@ -13,7 +13,7 @@ from k8s_jobs.spec import (
     ConfigMapSpecSource,
     JobGenerator,
     JobSpecSource,
-    StaticSpecSource,
+    YamlStringSpecSource,
     YamlFileSpecSource,
 )
 
@@ -35,7 +35,7 @@ class JobDefinition:
 
     def spec_source(self) -> JobSpecSource:
         if self.spec:
-            return StaticSpecSource(yaml.safe_load(self.spec))
+            return YamlStringSpecSource(self.spec)
         elif self.spec_path:
             return YamlFileSpecSource(self.spec_path)
         else:

--- a/k8s_jobs/config.py
+++ b/k8s_jobs/config.py
@@ -13,7 +13,7 @@ from k8s_jobs.spec import (
     ConfigMapSpecSource,
     JobGenerator,
     JobSpecSource,
-    StaticJobSpecSource,
+    StaticSpecSource,
     YamlFileSpecSource,
 )
 
@@ -35,7 +35,7 @@ class JobDefinition:
 
     def spec_source(self) -> JobSpecSource:
         if self.spec:
-            return StaticJobSpecSource(yaml.safe_load(self.spec))
+            return StaticSpecSource(yaml.safe_load(self.spec))
         elif self.spec_path:
             return YamlFileSpecSource(self.spec_path)
         else:

--- a/k8s_jobs/file_reloader.py
+++ b/k8s_jobs/file_reloader.py
@@ -17,6 +17,8 @@ class FileReloader:
         self._lock = threading.Lock()
         self._last_modified: float = 0
 
+    # NOTE: ctime/mtime-based change detection is slightly racy depending on the
+    # filesystem precision.
     def maybe_reload(
         self
     ) -> Generator[io.TextIOBase, Optional[Callable[[], None]], None]:
@@ -36,6 +38,8 @@ class FileReloader:
             last_modified = self._last_modified
             if statbuf.st_mtime <= last_modified:
                 return
+
+        logger.info(f"Processing update to {self.path}")
 
         # Note that this read is not atomic with the statbuf check, since we don't want
         # to do IO under a lock, hence the CAS below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "k8s-jobs"
-version = "0.1.6"
+version = "0.1.7"
 description = "Async Job Manager + AWS Batch Replacement for K8s"
 authors = ["Daniel Tahara <dktahara@gmail.com>"]
 repository = "https://github.com/danieltahara/k8s-jobs"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     k8s_itest: Slow itest that uses a real k8s, configured by TEST_K8s_CONFIG_PATH
-addopts = -m 'not k8s_itest'
+addopts = -m 'not k8s_itest' --cov k8s_jobs

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -13,7 +13,7 @@ from k8s_jobs.config import (
     ReloadingJobDefinitionsRegister,
 )
 from k8s_jobs.exceptions import NotFoundException
-from k8s_jobs.spec import ConfigMapSpecSource, StaticSpecSource, YamlFileSpecSource
+from k8s_jobs.spec import ConfigMapSpecSource, YamlFileSpecSource, YamlStringSpecSource
 
 
 class TestJobDefinition:
@@ -24,7 +24,7 @@ class TestJobDefinition:
 
         source = jd.spec_source()
 
-        assert isinstance(source, StaticSpecSource)
+        assert isinstance(source, YamlStringSpecSource)
         assert source.get() == spec
 
     def test_file_spec(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -13,7 +13,7 @@ from k8s_jobs.config import (
     ReloadingJobDefinitionsRegister,
 )
 from k8s_jobs.exceptions import NotFoundException
-from k8s_jobs.spec import ConfigMapSpecSource, StaticJobSpecSource, YamlFileSpecSource
+from k8s_jobs.spec import ConfigMapSpecSource, StaticSpecSource, YamlFileSpecSource
 
 
 class TestJobDefinition:
@@ -24,7 +24,7 @@ class TestJobDefinition:
 
         source = jd.spec_source()
 
-        assert isinstance(source, StaticJobSpecSource)
+        assert isinstance(source, StaticSpecSource)
         assert source.get() == spec
 
     def test_file_spec(self):

--- a/test/unit/test_spec.py
+++ b/test/unit/test_spec.py
@@ -6,7 +6,7 @@ from kubernetes.client import V1ConfigMap, V1Job, V1ObjectMeta
 from k8s_jobs.spec import (
     ConfigMapSpecSource,
     JobGenerator,
-    StaticJobSpecSource,
+    StaticSpecSource,
     YamlFileSpecSource,
 )
 
@@ -55,7 +55,7 @@ class TestSpecSource:
 class TestJobGenerator:
     def test_unique_names(self):
         generator = JobGenerator(
-            StaticJobSpecSource(
+            StaticSpecSource(
                 V1Job(metadata=V1ObjectMeta(name="iloveyouabushelandapeck"))
             )
         )
@@ -69,7 +69,7 @@ class TestJobGenerator:
 
     def test_generate_with_dict_config(self):
         job = V1Job(metadata=V1ObjectMeta(name="iloveyouabushelandapeck"))
-        generator = JobGenerator(StaticJobSpecSource(job.to_dict()))
+        generator = JobGenerator(StaticSpecSource(job.to_dict()))
 
         j = generator.generate()
         assert (

--- a/test/unit/test_spec.py
+++ b/test/unit/test_spec.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import Mock
 import yaml
 
@@ -22,8 +23,11 @@ class TestSpecSource:
         c = YamlFileSpecSource(str(tmp_file_name))
         assert d1 == c.get()
 
+        # See FileReloader note about raciness
+        time.sleep(0.01)
         with open(tmp_file_name, "w+") as f:
             yaml.dump(d2, f)
+
         assert d2 == c.get()
 
     def test_yaml_config_source_templates(self, request, tmp_path):


### PR DESCRIPTION
Most of the specs use yaml under the hood, so create a YamlStringSpec and compose YamlFile and ConfigMapSpecs with it.

Make the default mapping for a string spec in a job definition config be a templateable string spec.