### PR TITLE
Multi-Container Pod Logs + Templating + Roles + Examples

### DIFF
--- a/examples/k8s/configmap-helloworld.yaml
+++ b/examples/k8s/configmap-helloworld.yaml
@@ -14,9 +14,12 @@ data:
       template:
         spec:
           containers:
-          - name: hello
-            image: ubuntu
-            command: ["echo", "helloworld"]
+            - name: hello
+              image: ubuntu
+              command: ["echo", "hello"]
+            - name: world
+              image: ubuntu
+              command: ["echo", "world"]
           restartPolicy: Never
       backoffLimit: 0
       activeDeadlineSeconds: 600

--- a/examples/k8s/job-helloworld.yaml
+++ b/examples/k8s/job-helloworld.yaml
@@ -8,7 +8,10 @@ spec:
       containers:
       - name: hello
         image: ubuntu
-        command: ["echo", "helloworld"]
+        command: ["echo", "hello"]
+      - name: world
+        image: ubuntu
+        command: ["echo", "world"]
       restartPolicy: Never
   backoffLimit: 0
   activeDeadlineSeconds: 600

--- a/examples/k8s/role.yaml
+++ b/examples/k8s/role.yaml
@@ -7,7 +7,7 @@ rules:
 - apiGroups: ["batch"]
   resources:
     - "jobs"
-  verbs: ["create", "get", "list", "delete"]
+  verbs: ["create", "delete", "get", "list", "patch"]
 - apiGroups: ["batch"]
   resources:
     - "jobs/status"

--- a/k8s_jobs/spec.py
+++ b/k8s_jobs/spec.py
@@ -43,7 +43,19 @@ class YamlStringSpecSource(JobSpecSource):
         self.spec = spec
 
     def get(self, template_args: Optional[Dict] = None) -> Union[client.V1Job, Dict]:
-        rendered = jinja2.Template(self.spec).render(template_args or {})
+        """
+        Returns a strict template, raising exception when expected template args are NOT
+        provided.
+
+        Note that the converse is not true. You are free to provide unnecessary template
+        args.
+
+        Raises:
+            jinja2.exceptions.UndefinedError
+        """
+        rendered = jinja2.Template(self.spec, undefined=jinja2.StrictUndefined).render(
+            template_args or {}
+        )
         stream = StringIO(rendered)
         return yaml.safe_load(stream)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "k8s-jobs"
-version = "0.1.8"
+version = "0.1.9"
 description = "Async Job Manager + AWS Batch Replacement for K8s"
 authors = ["Daniel Tahara <dktahara@gmail.com>"]
 repository = "https://github.com/danieltahara/k8s-jobs"


### PR DESCRIPTION
Handle multi-container pod logs
Make yaml templating strict and raise when missing an arg
Fix roles
Update examples

Resolves https://github.com/danieltahara/k8s-jobs/issues/31
Resolves https://github.com/danieltahara/k8s-jobs/issues/32